### PR TITLE
Add fields required/recommended for cargo publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "thesis"
 version = "0.1.0"
 authors = ["Nate Mara <nate@onesignal.com>"]
 edition = "2018"
+description = "Rust library for controling & monitoring experimental refactors"
+readme = "README.md"
+repository = "https://github.com/OneSignal/thesis"
+license = "MIT"
+keywords = ["refactoring"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
We should provide some metadata to make discovery easier.