### PR TITLE
Deprecate impl RolloutStrategy for f64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 # 0.2.0
 
-- Deprecated `impl RolloutStrategy for f64` in favor of the `Ratio` rollout strategy
+- Deprecated `impl RolloutStrategy for f64` in favor of the `Percent` rollout strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.1.0
+
+- Initial relese
+
+# 0.2.0
+
+- Deprecated `impl RolloutStrategy for f64` in favor of the `Ratio` rollout strategy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thesis"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nate Mara <nate@onesignal.com>"]
 edition = "2018"
 description = "Rust library for controlling & monitoring experimental code paths"

--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ discarding the redis data if so. Here's how we can use an `Experiment` to do
 this.
 
 ```rust
+use thesis::{Experiment, rollout::Ratio};
+
 async fn load_data_from_db(id: i32) -> i32 { id }
 async fn load_data_from_redis(id: i32) -> i32 { id }
 
 let id = 4;
-use thesis::Experiment;
 let result = Experiment::new("load_data_from_db => load_data_from_redis")
     .control(load_data_from_db(id))
     .experimental(load_data_from_redis(id))
-    .rollout_strategy(0.005)
+    .rollout_strategy(Ratio::new(0.005))
     .on_mismatch(|mismatch| {
         eprintln!(
             "DB & Redis data differ - db={}, redis={}",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ discarding the redis data if so. Here's how we can use an `Experiment` to do
 this.
 
 ```rust
-use thesis::{Experiment, rollout::Ratio};
+use thesis::{Experiment, rollout::Percent};
 
 async fn load_data_from_db(id: i32) -> i32 { id }
 async fn load_data_from_redis(id: i32) -> i32 { id }
@@ -26,7 +26,7 @@ let id = 4;
 let result = Experiment::new("load_data_from_db => load_data_from_redis")
     .control(load_data_from_db(id))
     .experimental(load_data_from_redis(id))
-    .rollout_strategy(Ratio::new(0.005))
+    .rollout_strategy(Percent::new(0.5))
     .on_mismatch(|mismatch| {
         eprintln!(
             "DB & Redis data differ - db={}, redis={}",

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -172,6 +172,7 @@ impl<T, C, E, R, M> Experiment<T, C, E, R, M> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rollout::Ratio;
 
     #[tokio::test]
     async fn it_resolves_conflict_with_mismatch() {
@@ -183,7 +184,7 @@ mod tests {
                 experimental = !experimental;
                 experimental
             })
-            .rollout_strategy(0.5)
+            .rollout_strategy(Ratio::new(0.5))
             .on_mismatch(|mismatch| {
                 assert_eq!(mismatch.control, true);
                 assert_eq!(mismatch.experimental, false);
@@ -205,7 +206,7 @@ mod tests {
             let exists = Experiment::new("test")
                 .control(async { true })
                 .experimental(async { false })
-                .rollout_strategy(0.05)
+                .rollout_strategy(Ratio::new(0.05))
                 .on_mismatch(|mismatch| {
                     mismatch.experimental
                 })

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -172,7 +172,7 @@ impl<T, C, E, R, M> Experiment<T, C, E, R, M> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rollout::Ratio;
+    use crate::rollout::Percent;
 
     #[tokio::test]
     async fn it_resolves_conflict_with_mismatch() {
@@ -184,7 +184,7 @@ mod tests {
                 experimental = !experimental;
                 experimental
             })
-            .rollout_strategy(Ratio::new(0.5))
+            .rollout_strategy(Percent::new(50.0))
             .on_mismatch(|mismatch| {
                 assert_eq!(mismatch.control, true);
                 assert_eq!(mismatch.experimental, false);
@@ -206,7 +206,7 @@ mod tests {
             let exists = Experiment::new("test")
                 .control(async { true })
                 .experimental(async { false })
-                .rollout_strategy(Ratio::new(0.05))
+                .rollout_strategy(Percent::new(5.0))
                 .on_mismatch(|mismatch| {
                     mismatch.experimental
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! this.
 //!
 //! ```
-//! use thesis::{Experiment, rollout::Ratio};
+//! use thesis::{Experiment, rollout::Percent};
 //!
 //! async fn load_data_from_db(id: i32) -> i32 { id }
 //! async fn load_data_from_redis(id: i32) -> i32 { id }
@@ -23,7 +23,7 @@
 //! let result = Experiment::new("redis migration")
 //!     .control(load_data_from_db(id))
 //!     .experimental(load_data_from_redis(id))
-//!     .rollout_strategy(Ratio::new(0.005))
+//!     .rollout_strategy(Percent::new(0.5))
 //!     .on_mismatch(|mismatch| {
 //!         eprintln!(
 //!             "DB & Redis data differ - db={}, redis={}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,16 +13,17 @@
 //! this.
 //!
 //! ```
+//! use thesis::{Experiment, rollout::Ratio};
+//!
 //! async fn load_data_from_db(id: i32) -> i32 { id }
 //! async fn load_data_from_redis(id: i32) -> i32 { id }
 //!
 //! # tokio_test::block_on(async {
 //! let id = 4;
-//! use thesis::Experiment;
 //! let result = Experiment::new("redis migration")
 //!     .control(load_data_from_db(id))
 //!     .experimental(load_data_from_redis(id))
-//!     .rollout_strategy(0.005)
+//!     .rollout_strategy(Ratio::new(0.005))
 //!     .on_mismatch(|mismatch| {
 //!         eprintln!(
 //!             "DB & Redis data differ - db={}, redis={}",

--- a/src/rollout.rs
+++ b/src/rollout.rs
@@ -20,13 +20,21 @@ pub trait RolloutStrategy {
 
 /// The simplest rollout strategy, a floating point number between 0 and 1 that
 /// represents the percentage of requests which should use the experimental
-/// method. The experimental results will be compared to the control results when
-/// using the default f64 implementation.
-impl RolloutStrategy for f64 {
+/// method. The experimental results will be compared to the control results.
+pub struct Ratio(f64);
+
+impl Ratio {
+    /// Create a new rollout Ratio
+    pub fn new(ratio: f64) -> Self {
+        Self(ratio)
+    }
+}
+
+impl RolloutStrategy for Ratio {
     fn rollout_decision(&self) -> RolloutDecision {
         let mut rng = rand::thread_rng();
 
-        if rng.gen::<f64>() < *self {
+        if rng.gen::<f64>() < self.0 {
             RolloutDecision::UseExperimentalAndCompare
         } else {
             RolloutDecision::UseControl

--- a/src/rollout.rs
+++ b/src/rollout.rs
@@ -18,19 +18,19 @@ pub trait RolloutStrategy {
     fn rollout_decision(&self) -> RolloutDecision;
 }
 
-/// The simplest rollout strategy, a floating point number between 0 and 1 that
+/// The simplest rollout strategy, a floating point number between 0 and 100 that
 /// represents the percentage of requests which should use the experimental
 /// method. The experimental results will be compared to the control results.
-pub struct Ratio(f64);
+pub struct Percent(f64);
 
-impl Ratio {
-    /// Create a new rollout Ratio
-    pub fn new(ratio: f64) -> Self {
-        Self(ratio)
+impl Percent {
+    /// Create a new rollout Percent
+    pub fn new(percent: f64) -> Self {
+        Self(percent / 100.0)
     }
 }
 
-impl RolloutStrategy for Ratio {
+impl RolloutStrategy for Percent {
     fn rollout_decision(&self) -> RolloutDecision {
         let mut rng = rand::thread_rng();
 


### PR DESCRIPTION
`.rollout_strategy(0.5)` is very unclear, why is 0.5 a strategy? This
change introduces the `rollout::Ratio` type which makes the connection
between the rollout strategy and the f64 more explicit.