### PR TITLE
Support Result values in Experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,10 @@
 # 0.2.0
 
 - Deprecated `impl RolloutStrategy for f64` in favor of the `Percent` rollout strategy
+
+# 0.3.0
+
+- Introduce the `run_result` method with special handling for `Result` values
+- Remove `RolloutDecision::UseExperimental`
+- Remove `thesis_experiment_run_mismatch` metric in favor of the more general
+  `thesis_experiment_outcome`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thesis"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nate Mara <nate@onesignal.com>"]
 edition = "2018"
 description = "Rust library for controlling & monitoring experimental code paths"

--- a/src/rollout.rs
+++ b/src/rollout.rs
@@ -5,9 +5,6 @@ pub enum RolloutDecision {
     /// Run only the control method
     UseControl,
 
-    /// Run only the experimental method
-    UseExperimental,
-
     /// Run both methods concurrently and compare the results. If the results do
     /// not match, the `on_mismatch` handler will be run.
     UseExperimentalAndCompare,


### PR DESCRIPTION
More often than not, these kind of refactors will involve failable
methods. For this, thesis provides the `run_result` method which adds
special handling, metrics, and fallthrough logic for failable futures.