### PR TITLE
Remove PartialEq bound from Experiment::new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thesis"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Nate Mara <nate@onesignal.com>"]
 edition = "2018"
 description = "Rust library for controlling & monitoring experimental code paths"


### PR DESCRIPTION
When constructing an experiment which will be used with `run_result`, we
don't want to constrain the Result type to be PartialEq. Most Error
types are not PartialEq. Since we still have the `T: PartialEq` bound on
the `run` function, we still have this enforced where it counts.