### PR TITLE
Fix span heirarchy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thesis"
-version = "0.5.0"
-authors = ["Nate Mara <nate@onesignal.com>"]
+version = "0.5.1"
+authors = ["Lily Mara <lilymara@onesignal.com>"]
 edition = "2018"
 description = "Rust library for controlling & monitoring experimental code paths"
 readme = "README.md"


### PR DESCRIPTION
The spans for the control and experimental decision branches were not
properly nested under `Experiment::run` because they were created before
the `run` span begins. This commit fixes that bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/thesis/10)
<!-- Reviewable:end -->
