### PR TITLE
Impl `RolloutStrategy` for `RolloutDecision`

### DIFF
--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -399,7 +399,7 @@ mod tests {
         let exists = Experiment::new("test")
             .control(async { Ok::<_, &str>(true) })
             .experimental(async { Ok::<_, &str>(false) })
-            .rollout_strategy(Percent::new(0.0))
+            .rollout_strategy(RolloutDecision::UseControl)
             .run_result()
             .await;
 
@@ -412,7 +412,7 @@ mod tests {
 
         is_send(
             Experiment::new("test")
-                .rollout_strategy(Percent::new(0.0))
+                .rollout_strategy(RolloutDecision::UseControl)
                 .control(async {}),
         );
     }
@@ -426,8 +426,7 @@ mod tests {
                 seen = true;
                 Err::<bool, &str>("failed")
             })
-            // Setting the percent to 100% ensures that we'll call the experimental builder
-            .rollout_strategy(Percent::new(100.0))
+            .rollout_strategy(RolloutDecision::UseExperimentalAndCompare)
             .run_result()
             .await;
 
@@ -441,8 +440,7 @@ mod tests {
         let exists = Experiment::new("test")
             .control(async { Err::<bool, &str>("failed") })
             .experimental(async { Ok::<_, &str>(true) })
-            // Setting the percent to 100% ensures that we'll call the experimental builder
-            .rollout_strategy(Percent::new(100.0))
+            .rollout_strategy(RolloutDecision::UseExperimentalAndCompare)
             .on_mismatch(|m| {
                 seen = true;
 
@@ -470,7 +468,7 @@ mod tests {
         let exists = Experiment::new("test")
             .control(async { Err::<bool, NonPartialEq>(NonPartialEq) })
             .experimental(async { Ok::<_, NonPartialEq>(true) })
-            .rollout_strategy(Percent::new(100.0))
+            .rollout_strategy(RolloutDecision::UseExperimentalAndCompare)
             .on_mismatch(|m| {
                 seen = true;
 

--- a/src/rollout.rs
+++ b/src/rollout.rs
@@ -1,6 +1,7 @@
 use rand::Rng;
 
 /// A decision of if the control or experimental methods should be used
+#[derive(Clone, Copy)]
 pub enum RolloutDecision {
     /// Run only the control method
     UseControl,
@@ -13,6 +14,12 @@ pub enum RolloutDecision {
 /// A method for chosing if the control or experimental code should run
 pub trait RolloutStrategy {
     fn rollout_decision(&self) -> RolloutDecision;
+}
+
+impl RolloutStrategy for RolloutDecision {
+    fn rollout_decision(&self) -> RolloutDecision {
+        *self
+    }
 }
 
 /// The simplest rollout strategy, a floating point number between 0 and 100 that


### PR DESCRIPTION
This is a convenience to support passing a hardcoded decision to the `rollout_strategy` builder. Further, it updates tests that previously used percentages to force behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/thesis/16)
<!-- Reviewable:end -->
