### PR TITLE
adding a UseExperimental for exclusive switch between branches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thesis"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Lily Mara <lilymara@onesignal.com>"]
 edition = "2018"
 description = "Rust library for controlling & monitoring experimental code paths"

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -509,7 +509,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_calls_experimental_and_ignores_control() {
+    async fn it_runs_experimental_result_and_ignores_control() {
         let mut seen = false;
         let exists = Experiment::new("test")
             .control(async {
@@ -523,6 +523,22 @@ mod tests {
 
         assert_eq!(exists, Ok(true));
         // should not change seen due to only UseExperimental
-        assert_eq!(seen, false);
+        assert!(!seen);
+    }
+
+    #[tokio::test]
+    async fn it_runs_experimental_and_ignores_control() {
+        let mut experimental = false;
+        let exists = Experiment::new("test")
+            .control(async { false })
+            .experimental(async {
+                experimental = !experimental;
+                experimental
+            })
+            .rollout_strategy(RolloutDecision::UseExperimental)
+            .run()
+            .await;
+
+        assert!(exists);
     }
 }

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -193,6 +193,16 @@ impl<T, C, E, R, M> Experiment<T, C, E, R, M> {
 
                     control
                 }
+                RolloutDecision::UseExperimental => {
+                    counter!(
+                        "thesis_experiment_run_variant",
+                        "name" => self.name,
+                        "kind" => "experimental",
+                    )
+                    .increment(1);
+
+                    instrument_experimental(self.name, self.experimental_builder).await
+                }
             }
         }
         .instrument(span)
@@ -326,6 +336,20 @@ impl<T, Err, C, E, R, M> Experiment<Result<T, Err>, C, E, R, M> {
                         }
                         (Err(control), Err(_)) => Err(control),
                     }
+                }
+                RolloutDecision::UseExperimental => {
+                    counter!(
+                        "thesis_experiment_run_variant",
+                        "name" => self.name,
+                        "kind" => "experimental",
+                    )
+                    .increment(1);
+
+                    let result =
+                        instrument_experimental(self.name, self.experimental_builder).await;
+                    outcome(self.name, "experimental", &result);
+
+                    result
                 }
             }
         }
@@ -482,5 +506,23 @@ mod tests {
         }
 
         assert!(seen);
+    }
+
+    #[tokio::test]
+    async fn it_calls_experimental_and_ignores_control() {
+        let mut seen = false;
+        let exists = Experiment::new("test")
+            .control(async {
+                seen = true;
+                Err::<bool, &str>("failed")
+            })
+            .experimental(async { Ok::<_, &str>(true) })
+            .rollout_strategy(RolloutDecision::UseExperimental)
+            .run_result()
+            .await;
+
+        assert_eq!(exists, Ok(true));
+        // should not change seen due to only UseExperimental
+        assert_eq!(seen, false);
     }
 }

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -528,13 +528,9 @@ mod tests {
 
     #[tokio::test]
     async fn it_runs_experimental_and_ignores_control() {
-        let mut experimental = false;
         let exists = Experiment::new("test")
             .control(async { false })
-            .experimental(async {
-                experimental = !experimental;
-                experimental
-            })
+            .experimental(async { true })
             .rollout_strategy(RolloutDecision::UseExperimental)
             .run()
             .await;

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -528,13 +528,18 @@ mod tests {
 
     #[tokio::test]
     async fn it_runs_experimental_and_ignores_control() {
+        let mut not_seen = true;
         let exists = Experiment::new("test")
-            .control(async { false })
+            .control(async {
+                not_seen = false;
+                not_seen
+            })
             .experimental(async { true })
             .rollout_strategy(RolloutDecision::UseExperimental)
             .run()
             .await;
 
         assert!(exists);
+        assert!(not_seen);
     }
 }

--- a/src/rollout.rs
+++ b/src/rollout.rs
@@ -9,6 +9,9 @@ pub enum RolloutDecision {
     /// Run both methods concurrently and compare the results. If the results do
     /// not match, the `on_mismatch` handler will be run.
     UseExperimentalAndCompare,
+
+    // Run only the experimental method
+    UseExperimental,
 }
 
 /// A method for chosing if the control or experimental code should run


### PR DESCRIPTION
for some of our experiments, we want to be able to FF between not just control and control+experimental, but also exclusively experimental.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/thesis/19)
<!-- Reviewable:end -->
